### PR TITLE
style: enlarge group buy card title and body text to match coupon card

### DIFF
--- a/style.css
+++ b/style.css
@@ -80,8 +80,8 @@
 
   /* 標題 */
   .masonry-card-title {
-    font-size: 13px;
-    font-weight: 600;
+    font-size: 18px;
+    font-weight: 700;
     line-height: 1.3;
     margin: 0;
     display: -webkit-box;
@@ -106,7 +106,7 @@
 
   /* 描述文字 */
   .masonry-card-content p {
-    font-size: 11px;
+    font-size: 12px;
     line-height: 1.4;
     margin: 0;
     display: -webkit-box;
@@ -307,7 +307,7 @@
   }
 
   .masonry-card-title {
-    font-size: 16px;
+    font-size: 18px;
     font-weight: 700;
     line-height: 1.4;
     margin-bottom: 8px;


### PR DESCRIPTION
- Mobile title: 13px/600 → 18px/700 (matching coupon card h3)
- Mobile body: 11px → 12px (matching coupon card p)
- Tablet title: 16px → 18px (matching coupon card text-lg)

https://claude.ai/code/session_01HtJ86WS5jA2vEVTaGHBXG8